### PR TITLE
Fixes a PHP Notice problem. 

### DIFF
--- a/plugins/Kcfinder/vendor/core/uploader.php
+++ b/plugins/Kcfinder/vendor/core/uploader.php
@@ -141,7 +141,7 @@ class uploader {
             ini_set('session.cookie_domain', $_CONFIG['_sessionDomain']);
         switch ($this->cms) {
             case "drupal": break;
-            default: session_start(); break;
+            default: @session_start(); break;
         }
 
         // RELOAD DEFAULT CONFIGURATION


### PR DESCRIPTION
`Notice: A session had already been started - ignoring session_start() in  var/www/zk135/plugins/Kcfinder/vendor/core/uploader.php on line 144`

WARNING: If Kcfinder is updated, this has to be done again!

This notice destroys functionality. Kcfinder can't load properly if this notice is displayed.
